### PR TITLE
I've added support for retrieving a single report as Json, by adding …

### DIFF
--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -17,3 +17,4 @@ GET        /export                     controllers.DownloadController.show
 GET        /export/csv                 controllers.DownloadController.export
 GET        /export/json                controllers.DownloadController.json
 
+GET        /api/reports/count          controllers.ApiController.count

--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -15,4 +15,5 @@ GET        /report/:reportId           controllers.SearchController.view(reportI
 
 GET        /export                     controllers.DownloadController.show
 GET        /export/csv                 controllers.DownloadController.export
+GET        /export/json                controllers.DownloadController.json
 

--- a/src/main/scala/controllers/ApiController.scala
+++ b/src/main/scala/controllers/ApiController.scala
@@ -15,24 +15,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package services
+package controllers
 
-import com.google.inject.ImplementedBy
-import models.{CompaniesHouseId, Report, ReportId}
-import org.joda.time.LocalDate
-import org.reactivestreams.Publisher
-import slicks.repos.ReportTable
+import javax.inject.Inject
 
-import scala.concurrent.Future
+import play.api.libs.json.Json._
+import play.api.mvc.{Action, Controller}
+import services._
 
-@ImplementedBy(classOf[ReportTable])
-trait ReportService {
-  def find(id: ReportId): Future[Option[Report]]
+import scala.concurrent.ExecutionContext
 
-  def byCompanyNumber(companiesHouseId: CompaniesHouseId): Future[Seq[Report]]
-
-  def list(cutoffDate: LocalDate): Publisher[Report]
-
-  def count: Future[Int]
-
+class ApiController @Inject()(
+  val reportService: ReportService
+)(implicit val ec: ExecutionContext)
+  extends Controller {
+  //noinspection TypeAnnotation
+  def count = Action.async {
+    reportService.count.map(count => Ok(obj("reportCount" -> count)))
+  }
 }

--- a/src/main/scala/forms/DateRange.scala
+++ b/src/main/scala/forms/DateRange.scala
@@ -19,6 +19,7 @@ package forms
 
 import org.joda.time.{LocalDate, Months}
 import org.scalactic.TripleEquals._
+import play.api.libs.json.{Json, OFormat}
 
 case class DateRange(startDate: LocalDate, endDate: LocalDate) {
   def startsOnOrAfter(localDate: LocalDate): Boolean = !startDate.isBefore(localDate)
@@ -36,4 +37,8 @@ case class DateRange(startDate: LocalDate, endDate: LocalDate) {
     else
       input.plusMonths(months)
   }
+}
+
+object DateRange {
+  implicit val format: OFormat[DateRange] = Json.format
 }

--- a/src/main/scala/models/Report.scala
+++ b/src/main/scala/models/Report.scala
@@ -17,28 +17,32 @@
 
 package models
 
+import com.wellfactored.playbindings.ValueClassFormats
 import dbrows.{ContractDetailsRow, ReportRow}
 import forms.DateRange
 import forms.report._
 import org.joda.time.LocalDate
+import play.api.libs.json.{Json, OWrites}
 import utils.YesNo
 
 case class Report(
-                   id: ReportId,
-                   companyName: String,
-                   companyId: CompaniesHouseId,
-                   filingDate: LocalDate,
+  id: ReportId,
+  companyName: String,
+  companyId: CompaniesHouseId,
+  filingDate: LocalDate,
 
-                   approvedBy: String,
-                   confirmationEmailAddress: String,
+  approvedBy: String,
+  confirmationEmailAddress: String,
 
-                   reportDates: DateRange,
-                   paymentCodes: ConditionalText,
+  reportDates: DateRange,
+  paymentCodes: ConditionalText,
 
-                   contractDetails: Option[ContractDetails]
-                 )
+  contractDetails: Option[ContractDetails]
+)
 
-object Report {
+object Report extends ValueClassFormats {
+  implicit val write: OWrites[Report] = Json.writes[Report]
+
   def apply(r: (ReportRow, Option[ContractDetailsRow])): Report = {
     val (reportRow, contractDetailsRow) = r
     import reportRow._
@@ -78,10 +82,14 @@ object Report {
 }
 
 case class ContractDetails(
-                            paymentTerms: PaymentTerms,
-                            paymentHistory: PaymentHistory,
-                            offerEInvoicing: YesNo,
-                            offerSupplyChainFinance: YesNo,
-                            retentionChargesInPolicy: YesNo,
-                            retentionChargesInPast: YesNo
-                          )
+  paymentTerms: PaymentTerms,
+  paymentHistory: PaymentHistory,
+  offerEInvoicing: YesNo,
+  offerSupplyChainFinance: YesNo,
+  retentionChargesInPolicy: YesNo,
+  retentionChargesInPast: YesNo
+)
+
+object ContractDetails {
+  implicit def writes: OWrites[ContractDetails] = Json.writes[ContractDetails]
+}

--- a/src/main/scala/slicks/repos/ReportTable.scala
+++ b/src/main/scala/slicks/repos/ReportTable.scala
@@ -67,5 +67,5 @@ class ReportTable @Inject()(dbConfigProvider: DatabaseConfigProvider)(implicit e
     db.stream(disableAutocommit andThen action).mapResult(Report.apply)
   }
 
-
+  def count: Future[Int] = db.run(reportTable.length.result)
 }

--- a/src/main/scala/utils/YesNo.scala
+++ b/src/main/scala/utils/YesNo.scala
@@ -18,13 +18,13 @@
 package utils
 
 import enumeratum.EnumEntry.Lowercase
-import enumeratum.{Enum, EnumEntry}
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 
 sealed trait YesNo extends EnumEntry with Lowercase {
   def toBoolean: Boolean
 }
 
-object YesNo extends Enum[YesNo] with EnumFormatter[YesNo] {
+object YesNo extends Enum[YesNo] with EnumFormatter[YesNo] with PlayJsonEnum[YesNo] {
   override def values = findValues
 
   def fromBoolean(b: Boolean): YesNo = if (b) Yes else No


### PR DESCRIPTION
…a `Accept: application/json` header to the `/report/view/{id}` request, and for retrieving all reports for the last 24 months as Json via a `/export/json` endpoint.